### PR TITLE
slides-fr: slide 34: correction de la description de l'URL

### DIFF
--- a/slides-fr.html
+++ b/slides-fr.html
@@ -648,7 +648,7 @@
         Visitez <a href="http://ladieslearningcode.com">Ladies Learning Code</a>.
         ```
 
-        L'exemple ci-dessus utilise un lien **absolut**. Identique à un UTL tapé dans le navigateur, il est complet et démarre avec un `http://`.
+        L'exemple ci-dessus utilise un lien **absolut**. Identique à un URL tapé dans le navigateur, il est complet et commence par un `http://`.
 
         <!-- .element: class="note" -->**Note**: Le texte cliquable va entre les balises `<a>`  ouvrantes et fermantes.
       </script>
@@ -891,7 +891,7 @@
 
         La bonne pratique souhaite que vous ayez un dossier séparé pour organiser vos images. Votre dossier **project** possède déjà un dossier **images**.
 
-        Utilisez l'image **profile.jpg** fournie ou utlisez celle de votre choix et ajoutez-la au dossier.
+        Utilisez l'image **profile.jpg** fournie ou uRlisez celle de votre choix et ajoutez-la au dossier.
 
         Ou utilisez un élément subtitut (*placehoder*)! Voici quelques ressources amusantes:
 
@@ -1215,7 +1215,7 @@
         Vous pouvez utiliser un des 3 types de valeurs de couleurs
 
         * **mot clé** - La pluspart des couleurs de bases (red, green, blue, pink, etc) vont fonctionner.  Il en existe quelques funkys aussi comme "papayaWhip" et "paleGoldenrod"! Essayez-les tous ;)
-        * **RGB (red-green-blue)** - Utlisent les 3 valeurs numériques à partir de 0 (qui représente le noir) à 255 (le blanc).
+        * **RGB (red-green-blue)** - URlisent les 3 valeurs numériques à partir de 0 (qui représente le noir) à 255 (le blanc).
         * **hex code** - Utilise un le symbol (`#`) suivis d'un code hexadécimal donc composé de lettres et de chiffres (0-9, A-F).
 
         ```
@@ -1533,7 +1533,7 @@ text-transform: lowercase;</textarea>
           * Vous pouvez aussi enlever le soulignement par défaut grâce au CSS!
           * Une référence pour [les couleurs CSS](#colours) (syntax & colour Ressources).
 
-        1. Utilisez un *sélecteur de descendance* pour changer la `font-size`(taille) du `h1` et du `h2` dans le `header`.(Le projet LLC utlise respectivement les tailles 48px et 24px.)
+        1. Utilisez un *sélecteur de descendance* pour changer la `font-size`(taille) du `h1` et du `h2` dans le `header`.(Le projet LLC uRlise respectivement les tailles 48px et 24px.)
 
         **Bonus**: Sélectionnez une image d'arrière-plan pour votre page d'acceuil.
 
@@ -1608,7 +1608,7 @@ text-transform: lowercase;</textarea>
 
 
         <!-- ![](framework/img/workshop/box-model.gif) -->
-        ![](framework/img/workshop/box-model-outline.jpg)
+        ![](framework/img/workshop/box-model-ouRline.jpg)
       </script>
     </section>
 
@@ -1643,7 +1643,7 @@ text-transform: lowercase;</textarea>
         padding: 20px;</textarea>
         <div id="padding">padding test</div>
 
-        <!-- .element: class="note" -->**Note**: On peut donner des valeurs en utlisant plusieurs unités de mesure. Apprenez-en davantage par [ici](https://developer.mozilla.org/en/docs/Web/CSS/length).
+        <!-- .element: class="note" -->**Note**: On peut donner des valeurs en uRlisant plusieurs unités de mesure. Apprenez-en davantage par [ici](https://developer.mozilla.org/en/docs/Web/CSS/length).
       </script>
     </section>
 
@@ -2222,7 +2222,7 @@ text-transform: lowercase;</textarea>
       <script type="text/template">
         #Background-Size
 
-        `background-size` est utilisé pour modifier la taille de l'image d'arrière-plan sans avoir à éditer le fichier. Elle peut être utlisé en version longue comme ceci:
+        `background-size` est utilisé pour modifier la taille de l'image d'arrière-plan sans avoir à éditer le fichier. Elle peut être uRlisé en version longue comme ceci:
 
         ```
         .home {


### PR DESCRIPTION
Ce changement corrige une faute de frappe (UTL => URL), et clarifie la grammaire de la phrase.
